### PR TITLE
Atualiza dependência do reportlab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'click',
         'erpbrasil.base',
         'genshi',
-        'reportlab',
+        'reportlab>=3.5',
         'lxml',
         'py3o.template',
         'sh',


### PR DESCRIPTION
Recentemente eu tive um problema na geração do DANFE:

```
File "<string>", line 1, in <Expression '__py3o_frame(danfe.object_xml.NFe.chave_imagem, \'png\', isb64=True, dummy=2, origin_attrib={\'{urn:oasis:names:tc:opendocument:xmlns:drawing:1.0}style-name\': \'fr3\', \'{urn:oasis:names:tc:opendocument:xmlns:drawing:1.0}name\': "py3o.image(danfe.object_xml.NFe.chave_imagem, \'png\', isb64=True, dummy=2)", \'{urn:oasis:names:tc:opendocument:xmlns:text:1.0}anchor-type\': \'paragraph\', \'{urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0}width\': \'6.001cm\', \'{urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0}height\': \'0.801cm\', \'{urn:oasis:names:tc:opendocument:xmlns:drawing:1.0}z-index\': \'3\'})'>
  File "/usr/local/lib/python3.7/dist-packages/genshi/template/eval.py", line 307, in lookup_attr
    val = obj[key]
  File "src/lxml/objectify.pyx", line 289, in lxml.objectify.ObjectifiedElement.__getitem__
  File "src/lxml/objectify.pyx", line 450, in lxml.objectify._lookupChildOrRaise
AttributeError: no such child: {http://www.portalfiscal.inf.br/nfe}chave_imagem
```

Depois de alguns testes eu identifiquei que o reportlab do meu ambiente era a versão 3.3.0 e a versão que estava sendo usada nos testes do repo era a versão 3.5.67, ao atualizar a versão do reportlab no meu ambiente o problema acima foi solucionado, para evitar esse tipo de erro que é difícil de se detectar este PR adiciona a versão da dependência do reportlab.