### PR TITLE
[FIX] prazo de pagamento fatura

### DIFF
--- a/src/erpbrasil/edoc/pdf/danfe_formata.py
+++ b/src/erpbrasil/edoc/pdf/danfe_formata.py
@@ -379,8 +379,7 @@ def fatura_a_prazo(NFe):
 
 
 def fatura_a_vista(NFe):
-    fatura = fatura_a_prazo(NFe)
-    return not fatura
+    return not fatura_a_prazo(NFe)
 
 
 def numero_item(det):

--- a/src/erpbrasil/edoc/pdf/danfe_formata.py
+++ b/src/erpbrasil/edoc/pdf/danfe_formata.py
@@ -364,33 +364,22 @@ def cnpj_emitente_formatado(NFe):
 
 
 def fatura_a_prazo(NFe):
-    if not (len(str(NFe.infNFe.cobr.fat.nFat)) or
-            len(str(NFe.infNFe.cobr.fat.vOrig)) or
-            len(str(NFe.infNFe.cobr.fat.vDesc)) or
-            len(str(NFe.infNFe.cobr.fat.vLiq))):
-        return False
-
-    if (str(NFe.infNFe.ide.indPag) == '1' or
-            len(str(NFe.infNFe.cobr.dup)) > 1 or
-            ((len(str(NFe.infNFe.cobr.dup)) == 1) and
-             (datetime.strptime(str(NFe.infNFe.cobr.dup[0].dVenc),
-                                '%Y-%m-%d').toordinal() > datetime.strptime(
-                 str(NFe.infNFe.ide.dEmi.toordinal()),
-                 '%Y-%m-%d').toordinal()))):
+    # não funciona com multiplos detpag
+    if (
+        str(NFe.infNFe.pag.detPag.indPag) == "1"
+        or len(NFe.infNFe.cobr.dup) > 1
+        or (
+            len(NFe.infNFe.cobr.dup) == 1
+            and datetime.strptime(NFe.infNFe.cobr.dup[0].dVenc, "%d/%m/%Y").toordinal()
+            > datetime.strptime(NFe.infNFe.ide.dEmi, "%d/%m/%Y").toordinal()
+        )
+    ):
         return True
-
     return False
 
 
 def fatura_a_vista(NFe):
-    if not (len(str(NFe.infNFe.cobr.fat.nFat)) or
-            len(str(NFe.infNFe.cobr.fat.vOrig)) or
-            len(str(NFe.infNFe.cobr.fat.vDesc)) or
-            len(str(NFe.infNFe.cobr.fat.vLiq))):
-        return False
-
     fatura = fatura_a_prazo(NFe)
-
     return not fatura
 
 


### PR DESCRIPTION
A geração da DANFE estava com um bug:
![image](https://user-images.githubusercontent.com/634278/135380700-a0f4d787-017a-478f-8e6c-af6d6d19267e.png)

A informação "PAGAMENTO A VISTA" estava sendo exibida erroneamente na DANFE pois o que está definido no XML da NFe é pagamento a prazo, a nota fiscal foi emitidia dia 29/09/2021 o primeiro vencimento é em 30/10/2021.

Essa PR faz a correção do processamento dessa informação.
Comportamento após essa PR:
![image](https://user-images.githubusercontent.com/634278/135382348-faaf4f28-bcf6-4f23-bad5-c5bf2748a6d6.png)

testei o código da PR com uma nota fiscal a vista e a prazo e a informação está sendo carregado corretamente nos dois caso.

@rvalyi @renatonlima @marcelsavegnago @felipemotter @mileo 