### PR TITLE
[FIX] O campo CEP em um destinatário estrangeiro pode ser nulo

### DIFF
--- a/src/erpbrasil/edoc/pdf/nfe.py
+++ b/src/erpbrasil/edoc/pdf/nfe.py
@@ -13,7 +13,7 @@ NAO_OBRIGATORIO = [
     'veicTransp', 'placa', 'fone', 'transporta', 'vTotTrib', 'marca', 'nVol',
     'pesoL', 'vIPI', 'vol', 'IEST', 'CST', 'pIPI', 'RNTC', 'dhSaiEnt',
     'indPag', 'vBC', 'vICMS', 'pICMS', 'cobr', 'qVol', 'esp', 'pesoB', 'IE',
-    'IPI', 'nFat', 'vDesc',
+    'IPI', 'nFat', 'vDesc', 'CEP',
 ]
 
 TAGS_ICMS = [


### PR DESCRIPTION
Esse PR corrige o erro ao tentar imprimir um XML sem a tag de CEP do destinatário é gerado um erro de atributo inválido