### PR TITLE
Adiciona formatação nos campos do ICMSTot

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ Overview
     :alt: Supported implementations
     :target: https://pypi.org/project/erpbrasil.edoc.pdf
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.edoc.pdf/v1.1.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.edoc.pdf/v1.1.1.svg
     :alt: Commits since latest release
-    :target: https://github.com/erpbrasil/erpbrasil.edoc.pdf/compare/v1.1.0...master
+    :target: https://github.com/erpbrasil/erpbrasil.edoc.pdf/compare/v1.1.1...master
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ project = 'erpbrasil.edoc.pdf'
 year = '2020'
 author = 'KMEE'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '1.1.0'
+version = release = '1.1.1'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='erpbrasil.edoc.pdf',
-    version='1.1.0',
+    version='1.1.1',
     license='MIT',
     description='Impressão de documentos fiscais a partir do XML: NF-E, NFC-E, CT-E, MDF-E, GNRE e etc.',
     long_description='%s\n%s' % (

--- a/src/erpbrasil/edoc/pdf/__init__.py
+++ b/src/erpbrasil/edoc/pdf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from lxml import etree
 from lxml import objectify

--- a/src/erpbrasil/edoc/pdf/danfe_formata.py
+++ b/src/erpbrasil/edoc/pdf/danfe_formata.py
@@ -34,18 +34,32 @@ def formata_cinco_casas(valor):
     return formata_decimal(valor, 5)
 
 
+# Formata campos do ICMSTot
 formata_vBC = formata_duas_casas
 formata_vICMS = formata_duas_casas
+formata_vICMSDeson = formata_duas_casas
+formata_vFCPUFDest = formata_duas_casas
+formata_vICMSUFDest = formata_duas_casas
+formata_vICMSUFRemet = formata_duas_casas
+formata_vFCP = formata_duas_casas
 formata_vBCST = formata_duas_casas
 formata_vST = formata_duas_casas
-formata_vTotTrib = formata_duas_casas
+formata_vFCPST = formata_duas_casas
+formata_vFCPSTRet = formata_duas_casas
 formata_vProd = formata_duas_casas
 formata_vFrete = formata_duas_casas
 formata_vSeg = formata_duas_casas
 formata_vDesc = formata_duas_casas
-formata_vOutro = formata_duas_casas
+formata_vII = formata_duas_casas
 formata_vIPI = formata_duas_casas
+formata_vIPIDevol = formata_duas_casas
+formata_vPIS = formata_duas_casas
+formata_vCOFINS = formata_duas_casas
+formata_vOutro = formata_duas_casas
 formata_vNF = formata_duas_casas
+formata_vTotTrib = formata_duas_casas
+
+# Formata outros campos do Det
 formata_qCom = formata_tres_casas
 formata_vUnCom = formata_cinco_casas
 formata_vProd = formata_duas_casas


### PR DESCRIPTION
Alguns campos da tag ICMSTot não tem a formação definida como no caso do vPIS e vCOFINS, como agora são impressos no DANFE esses campos estão sem formatação.

![Screenshot from 2023-07-04 11-09-51](https://github.com/erpbrasil/erpbrasil.edoc.pdf/assets/211005/c1930275-b404-4738-87fa-b0cb22313c0f)

Eu aproveitei e defini a formatação de todos os campos da tag ICMSTot para caso seja necessário imprimir no DANFE futuramente.
